### PR TITLE
fix(kubernetes): use bitnami full archive repository for old charts

### DIFF
--- a/infrastructure/kubernetes/helmfile.d/20-habitcentric.yaml
+++ b/infrastructure/kubernetes/helmfile.d/20-habitcentric.yaml
@@ -5,6 +5,10 @@ environments:
   kuma:
   traefik-mesh:
 
+repositories:
+  - name: bitnami-archive-full-index
+    url: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+
 releases:
   - name: ui
     namespace: hc-ui
@@ -43,4 +47,3 @@ releases:
     values:
       - ./values/gateway-values.yaml.gotmpl
   {{- end }}
-

--- a/services/habit/helm/habit/Chart.lock
+++ b/services/habit/helm/habit/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   version: 9.8.5
-digest: sha256:72703fcf58856fe1665c93c0ef1e07cf9fb4723c239ccb76dc4fe34f2a650177
-generated: "2020-10-23T11:26:14.810996+02:00"
+digest: sha256:7cc5a83cd6866bf24d675f864df8e402aeeee092166877b79c75f379539c1dbf
+generated: "2022-07-01T14:05:59.917454+02:00"

--- a/services/habit/helm/habit/Chart.yaml
+++ b/services/habit/helm/habit/Chart.yaml
@@ -15,5 +15,5 @@ engine: gotpl
 dependencies:
   - name: postgresql
     version: 9.8.5
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: persistence.deployPostgres

--- a/services/track/helm/track/Chart.lock
+++ b/services/track/helm/track/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   version: 10.4.4
-digest: sha256:90cc50ff12309d728cc7cf4067704aa5dc1ee299139d65364752473f21fa5628
-generated: "2021-05-14T14:40:54.747299415+02:00"
+digest: sha256:5f402df7bd2c04b8a51eb72b20b493ed575782d6e64de428980123253dff543d
+generated: "2022-07-01T14:07:35.469546+02:00"

--- a/services/track/helm/track/Chart.yaml
+++ b/services/track/helm/track/Chart.yaml
@@ -15,5 +15,5 @@ engine: gotpl
 dependencies:
   - name: postgresql
     version: 10.4.4
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: persistence.deployPostgres


### PR DESCRIPTION
Bitnami added a retention policy for charts in their main Helm
repository. Helm charts are now kept for 6 months and removed
afterwards. Since the postgres chart used by habit and track service
are older than that, Helm could not find the specified charts when
deploying on Kubernetes.

See https://github.com/bitnami/charts/issues/10539