### PR TITLE
ci: fix handling of single quotes in release changelog

### DIFF
--- a/services/gateway/.releaserc.json
+++ b/services/gateway/.releaserc.json
@@ -9,7 +9,7 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     ["@semantic-release/exec", {
-      "prepareCmd": "mkdir -p release && echo '${nextRelease.version}' > release/version.txt && echo '${nextRelease.notes}' > release/notes.md"
+      "prepareCmd": "mkdir -p release && echo '${nextRelease.version}' > release/version.txt && echo '${nextRelease.notes.replaceAll('\\'', '\\'\"\\'\"\\'')}' > release/notes.md"
     }]
   ],
   "skipTag": true,

--- a/services/habit/.releaserc.json
+++ b/services/habit/.releaserc.json
@@ -9,7 +9,7 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     ["@semantic-release/exec", {
-      "prepareCmd": "mkdir -p release && echo '${nextRelease.version}' > release/version.txt && echo '${nextRelease.notes}' > release/notes.md"
+      "prepareCmd": "mkdir -p release && echo '${nextRelease.version}' > release/version.txt && echo '${nextRelease.notes.replaceAll('\\'', '\\'\"\\'\"\\'')}' > release/notes.md"
     }]
   ],
   "skipTag": true,

--- a/services/report/.releaserc.json
+++ b/services/report/.releaserc.json
@@ -9,7 +9,7 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     ["@semantic-release/exec", {
-      "prepareCmd": "mkdir -p release && echo '${nextRelease.version}' > release/version.txt && echo '${nextRelease.notes}' > release/notes.md"
+      "prepareCmd": "mkdir -p release && echo '${nextRelease.version}' > release/version.txt && echo '${nextRelease.notes.replaceAll('\\'', '\\'\"\\'\"\\'')}' > release/notes.md"
     }]
   ],
   "skipTag": true,

--- a/services/track/.releaserc.json
+++ b/services/track/.releaserc.json
@@ -9,7 +9,7 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     ["@semantic-release/exec", {
-      "prepareCmd": "mkdir -p release && echo '${nextRelease.version}' > release/version.txt && echo '${nextRelease.notes}' > release/notes.md"
+      "prepareCmd": "mkdir -p release && echo '${nextRelease.version}' > release/version.txt && echo '${nextRelease.notes.replaceAll('\\'', '\\'\"\\'\"\\'')}' > release/notes.md"
     }]
   ],
   "skipTag": true,

--- a/services/ui/.releaserc.json
+++ b/services/ui/.releaserc.json
@@ -9,7 +9,7 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     ["@semantic-release/exec", {
-      "prepareCmd": "mkdir -p release && echo '${nextRelease.version}' > release/version.txt && echo '${nextRelease.notes}' > release/notes.md"
+      "prepareCmd": "mkdir -p release && echo '${nextRelease.version}' > release/version.txt && echo '${nextRelease.notes.replaceAll('\\'', '\\'\"\\'\"\\'')}' > release/notes.md"
     }]
   ],
   "skipTag": true,

--- a/services/ui/public/mockServiceWorker.js
+++ b/services/ui/public/mockServiceWorker.js
@@ -2,22 +2,21 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (0.36.8).
+ * Mock Service Worker (0.43.1).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.
  */
 
-const INTEGRITY_CHECKSUM = '02f4ad4a2797f85668baf196e553d929'
-const bypassHeaderName = 'x-msw-bypass'
+const INTEGRITY_CHECKSUM = 'c9450df6e4dc5e45740c3b0b640727a2'
 const activeClientIds = new Set()
 
 self.addEventListener('install', function () {
-  return self.skipWaiting()
+  self.skipWaiting()
 })
 
-self.addEventListener('activate', async function (event) {
-  return self.clients.claim()
+self.addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
 })
 
 self.addEventListener('message', async function (event) {
@@ -33,7 +32,9 @@ self.addEventListener('message', async function (event) {
     return
   }
 
-  const allClients = await self.clients.matchAll()
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
 
   switch (event.data) {
     case 'KEEPALIVE_REQUEST': {
@@ -83,161 +84,6 @@ self.addEventListener('message', async function (event) {
   }
 })
 
-// Resolve the "main" client for the given event.
-// Client that issues a request doesn't necessarily equal the client
-// that registered the worker. It's with the latter the worker should
-// communicate with during the response resolving phase.
-async function resolveMainClient(event) {
-  const client = await self.clients.get(event.clientId)
-
-  if (client.frameType === 'top-level') {
-    return client
-  }
-
-  const allClients = await self.clients.matchAll()
-
-  return allClients
-    .filter((client) => {
-      // Get only those clients that are currently visible.
-      return client.visibilityState === 'visible'
-    })
-    .find((client) => {
-      // Find the client ID that's recorded in the
-      // set of clients that have registered the worker.
-      return activeClientIds.has(client.id)
-    })
-}
-
-async function handleRequest(event, requestId) {
-  const client = await resolveMainClient(event)
-  const response = await getResponse(event, client, requestId)
-
-  // Send back the response clone for the "response:*" life-cycle events.
-  // Ensure MSW is active and ready to handle the message, otherwise
-  // this message will pend indefinitely.
-  if (client && activeClientIds.has(client.id)) {
-    ;(async function () {
-      const clonedResponse = response.clone()
-      sendToClient(client, {
-        type: 'RESPONSE',
-        payload: {
-          requestId,
-          type: clonedResponse.type,
-          ok: clonedResponse.ok,
-          status: clonedResponse.status,
-          statusText: clonedResponse.statusText,
-          body:
-            clonedResponse.body === null ? null : await clonedResponse.text(),
-          headers: serializeHeaders(clonedResponse.headers),
-          redirected: clonedResponse.redirected,
-        },
-      })
-    })()
-  }
-
-  return response
-}
-
-async function getResponse(event, client, requestId) {
-  const { request } = event
-  const requestClone = request.clone()
-  const getOriginalResponse = () => fetch(requestClone)
-
-  // Bypass mocking when the request client is not active.
-  if (!client) {
-    return getOriginalResponse()
-  }
-
-  // Bypass initial page load requests (i.e. static assets).
-  // The absence of the immediate/parent client in the map of the active clients
-  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
-  // and is not ready to handle requests.
-  if (!activeClientIds.has(client.id)) {
-    return await getOriginalResponse()
-  }
-
-  // Bypass requests with the explicit bypass header
-  if (requestClone.headers.get(bypassHeaderName) === 'true') {
-    const cleanRequestHeaders = serializeHeaders(requestClone.headers)
-
-    // Remove the bypass header to comply with the CORS preflight check.
-    delete cleanRequestHeaders[bypassHeaderName]
-
-    const originalRequest = new Request(requestClone, {
-      headers: new Headers(cleanRequestHeaders),
-    })
-
-    return fetch(originalRequest)
-  }
-
-  // Send the request to the client-side MSW.
-  const reqHeaders = serializeHeaders(request.headers)
-  const body = await request.text()
-
-  const clientMessage = await sendToClient(client, {
-    type: 'REQUEST',
-    payload: {
-      id: requestId,
-      url: request.url,
-      method: request.method,
-      headers: reqHeaders,
-      cache: request.cache,
-      mode: request.mode,
-      credentials: request.credentials,
-      destination: request.destination,
-      integrity: request.integrity,
-      redirect: request.redirect,
-      referrer: request.referrer,
-      referrerPolicy: request.referrerPolicy,
-      body,
-      bodyUsed: request.bodyUsed,
-      keepalive: request.keepalive,
-    },
-  })
-
-  switch (clientMessage.type) {
-    case 'MOCK_SUCCESS': {
-      return delayPromise(
-        () => respondWithMock(clientMessage),
-        clientMessage.payload.delay,
-      )
-    }
-
-    case 'MOCK_NOT_FOUND': {
-      return getOriginalResponse()
-    }
-
-    case 'NETWORK_ERROR': {
-      const { name, message } = clientMessage.payload
-      const networkError = new Error(message)
-      networkError.name = name
-
-      // Rejecting a request Promise emulates a network error.
-      throw networkError
-    }
-
-    case 'INTERNAL_ERROR': {
-      const parsedBody = JSON.parse(clientMessage.payload.body)
-
-      console.error(
-        `\
-[MSW] Uncaught exception in the request handler for "%s %s":
-
-${parsedBody.location}
-
-This exception has been gracefully handled as a 500 response, however, it's strongly recommended to resolve this error, as it indicates a mistake in your code. If you wish to mock an error response, please see this guide: https://mswjs.io/docs/recipes/mocking-error-responses\
-`,
-        request.method,
-        request.url,
-      )
-
-      return respondWithMock(clientMessage)
-    }
-  }
-
-  return getOriginalResponse()
-}
-
 self.addEventListener('fetch', function (event) {
   const { request } = event
   const accept = request.headers.get('accept') || ''
@@ -265,9 +111,10 @@ self.addEventListener('fetch', function (event) {
     return
   }
 
-  const requestId = uuidv4()
+  // Generate unique request ID.
+  const requestId = Math.random().toString(16).slice(2)
 
-  return event.respondWith(
+  event.respondWith(
     handleRequest(event, requestId).catch((error) => {
       if (error.name === 'NetworkError') {
         console.warn(
@@ -290,14 +137,171 @@ self.addEventListener('fetch', function (event) {
   )
 })
 
-function serializeHeaders(headers) {
-  const reqHeaders = {}
-  headers.forEach((value, name) => {
-    reqHeaders[name] = reqHeaders[name]
-      ? [].concat(reqHeaders[name]).concat(value)
-      : value
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event)
+  const response = await getResponse(event, client, requestId)
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    ;(async function () {
+      const clonedResponse = response.clone()
+      sendToClient(client, {
+        type: 'RESPONSE',
+        payload: {
+          requestId,
+          type: clonedResponse.type,
+          ok: clonedResponse.ok,
+          status: clonedResponse.status,
+          statusText: clonedResponse.statusText,
+          body:
+            clonedResponse.body === null ? null : await clonedResponse.text(),
+          headers: Object.fromEntries(clonedResponse.headers.entries()),
+          redirected: clonedResponse.redirected,
+        },
+      })
+    })()
+  }
+
+  return response
+}
+
+// Resolve the main client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (client.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
   })
-  return reqHeaders
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event
+  const clonedRequest = request.clone()
+
+  function passthrough() {
+    // Clone the request because it might've been already used
+    // (i.e. its body has been read and sent to the cilent).
+    const headers = Object.fromEntries(clonedRequest.headers.entries())
+
+    // Remove MSW-specific request headers so the bypassed requests
+    // comply with the server's CORS preflight check.
+    // Operate with the headers as an object because request "Headers"
+    // are immutable.
+    delete headers['x-msw-bypass']
+
+    return fetch(clonedRequest, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Bypass requests with the explicit bypass header.
+  // Such requests can be issued by "ctx.fetch()".
+  if (request.headers.get('x-msw-bypass') === 'true') {
+    return passthrough()
+  }
+
+  // Create a communication channel scoped to the current request.
+  // This way events can be exchanged outside of the worker's global
+  // "message" event listener (i.e. abstracted into functions).
+  const operationChannel = new BroadcastChannel(
+    `msw-response-stream-${requestId}`,
+  )
+
+  // Notify the client that a request has been intercepted.
+  const clientMessage = await sendToClient(client, {
+    type: 'REQUEST',
+    payload: {
+      id: requestId,
+      url: request.url,
+      method: request.method,
+      headers: Object.fromEntries(request.headers.entries()),
+      cache: request.cache,
+      mode: request.mode,
+      credentials: request.credentials,
+      destination: request.destination,
+      integrity: request.integrity,
+      redirect: request.redirect,
+      referrer: request.referrer,
+      referrerPolicy: request.referrerPolicy,
+      body: await request.text(),
+      bodyUsed: request.bodyUsed,
+      keepalive: request.keepalive,
+    },
+  })
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.payload)
+    }
+
+    case 'MOCK_RESPONSE_START': {
+      return respondWithMockStream(operationChannel, clientMessage.payload)
+    }
+
+    case 'MOCK_NOT_FOUND': {
+      return passthrough()
+    }
+
+    case 'NETWORK_ERROR': {
+      const { name, message } = clientMessage.payload
+      const networkError = new Error(message)
+      networkError.name = name
+
+      // Rejecting a "respondWith" promise emulates a network error.
+      throw networkError
+    }
+
+    case 'INTERNAL_ERROR': {
+      const parsedBody = JSON.parse(clientMessage.payload.body)
+
+      console.error(
+        `\
+[MSW] Uncaught exception in the request handler for "%s %s":
+
+${parsedBody.location}
+
+This exception has been gracefully handled as a 500 response, however, it's strongly recommended to resolve this error, as it indicates a mistake in your code. If you wish to mock an error response, please see this guide: https://mswjs.io/docs/recipes/mocking-error-responses\
+`,
+        request.method,
+        request.url,
+      )
+
+      return respondWithMock(clientMessage.payload)
+    }
+  }
+
+  return passthrough()
 }
 
 function sendToClient(client, message) {
@@ -316,23 +320,48 @@ function sendToClient(client, message) {
   })
 }
 
-function delayPromise(cb, duration) {
+function sleep(timeMs) {
   return new Promise((resolve) => {
-    setTimeout(() => resolve(cb()), duration)
+    setTimeout(resolve, timeMs)
   })
 }
 
-function respondWithMock(clientMessage) {
-  return new Response(clientMessage.payload.body, {
-    ...clientMessage.payload,
-    headers: clientMessage.payload.headers,
-  })
+async function respondWithMock(response) {
+  await sleep(response.delay)
+  return new Response(response.body, response)
 }
 
-function uuidv4() {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-    const r = (Math.random() * 16) | 0
-    const v = c == 'x' ? r : (r & 0x3) | 0x8
-    return v.toString(16)
+function respondWithMockStream(operationChannel, mockResponse) {
+  let streamCtrl
+  const stream = new ReadableStream({
+    start: (controller) => (streamCtrl = controller),
+  })
+
+  return new Promise(async (resolve, reject) => {
+    operationChannel.onmessageerror = (event) => {
+      operationChannel.close()
+      return reject(event.data.error)
+    }
+
+    operationChannel.onmessage = (event) => {
+      if (!event.data) {
+        return
+      }
+
+      switch (event.data.type) {
+        case 'MOCK_RESPONSE_CHUNK': {
+          streamCtrl.enqueue(event.data.payload)
+          break
+        }
+
+        case 'MOCK_RESPONSE_END': {
+          streamCtrl.close()
+          operationChannel.close()
+        }
+      }
+    }
+
+    await sleep(mockResponse.delay)
+    return resolve(new Response(stream, mockResponse))
   })
 }

--- a/services/ui/src/overview/components/list/HabitList.test.tsx
+++ b/services/ui/src/overview/components/list/HabitList.test.tsx
@@ -6,20 +6,18 @@ import { renderWithoutSwrCache } from "../../../test-utils/swr/RenderWithoutSwrC
 import { trackedDatesMap } from "../../../test-utils/mocks/handlers";
 import { format } from "date-fns";
 
-jest.mock("../../api/track/api");
-
-it("renders list of three habits", async () => {
+it("renders list of four habits", async () => {
   renderWithoutSwrCache(<HabitList />);
   const list = await screen.findByRole("list", { name: /habits/i });
   const items = within(list).getAllByRole("listitem");
-  expect(items.length).toEqual(3);
+  expect(items.length).toEqual(4);
 });
 
 it("renders habit titles", async () => {
   renderWithoutSwrCache(<HabitList />);
   const items = await screen.findAllByRole("listitem");
   const titles = items.map((i) => within(i).getByRole("heading").textContent);
-  expect(titles).toEqual(["Jogging", "Programming", "Working out"]);
+  expect(titles).toEqual(["Jogging", "Programming", "Working out", "Cooking"]);
 });
 
 it("renders habit schedule", async () => {
@@ -27,6 +25,7 @@ it("renders habit schedule", async () => {
   expect(await screen.findByText(/once per day/i)).toBeInTheDocument();
   expect(await screen.findByText(/twice per week/i)).toBeInTheDocument();
   expect(await screen.findByText(/6 times per month/i)).toBeInTheDocument();
+  expect(await screen.findByText(/50 times per year/i)).toBeInTheDocument();
 });
 
 it("renders habit track buttons", async () => {
@@ -89,11 +88,8 @@ it("should open datepicker when track button is clicked", async () => {
 it("should highlight already tracked dates when datepicker is open", async () => {
   renderWithoutSwrCache(<HabitList />);
 
-  await clickJoggingTrackButton();
-  const regexForTrackedDates = `${format(
-    trackedDatesMap.get(1)![0],
-    "EEEE, MMMM do, yyyy"
-  )}|${format(trackedDatesMap.get(1)![1], "EEEE, MMMM do, yyyy")}`;
+  await clickCookingTrackButton();
+  const regexForTrackedDates = `${format(trackedDatesMap.get(4)![0], "EEEE, MMMM do, yyyy")}`;
 
   const alreadyTrackedDays = await screen.findAllByRole("option", {
     name: new RegExp(regexForTrackedDates, "i"),
@@ -106,20 +102,32 @@ it("should highlight already tracked dates when datepicker is open", async () =>
 it("should highlight date when date is selected", async () => {
   renderWithoutSwrCache(<HabitList />);
 
-  await clickJoggingTrackButton();
+  await clickWorkingOutTrackButton();
   let days = await screen.findAllByRole("option", {
     name: /Choose/i,
   });
   await userEvent.click(days[10]);
 
-  await waitFor(() => expect(days[10]).toHaveClass("react-datepicker__day--highlighted"), {
-    timeout: 10000,
-  });
+  await waitFor(() => expect(days[10]).toHaveClass("react-datepicker__day--highlighted"));
 });
 
 async function clickJoggingTrackButton() {
   const trackButton = await screen.findByRole("button", {
     name: /track jogging habit/i,
+  });
+  await userEvent.click(trackButton);
+}
+
+async function clickCookingTrackButton() {
+  const trackButton = await screen.findByRole("button", {
+    name: /track cooking habit/i,
+  });
+  await userEvent.click(trackButton);
+}
+
+async function clickWorkingOutTrackButton() {
+  const trackButton = await screen.findByRole("button", {
+    name: /track working out habit/i,
   });
   await userEvent.click(trackButton);
 }

--- a/services/ui/src/test-utils/mocks/handlers.ts
+++ b/services/ui/src/test-utils/mocks/handlers.ts
@@ -28,6 +28,14 @@ let habits = [
       repetitions: 6,
     },
   },
+  {
+    id: 4,
+    name: "Cooking",
+    schedule: {
+      frequency: "YEARLY",
+      repetitions: 50,
+    },
+  },
 ];
 
 function todayMinusDays(days: number): Date {
@@ -37,7 +45,8 @@ function todayMinusDays(days: number): Date {
 export const trackedDatesMap = new Map<number, TrackedDates>([
   [1, [todayMinusDays(1), todayMinusDays(2)]],
   [2, [todayMinusDays(3), todayMinusDays(4)]],
-  [3, [todayMinusDays(5), todayMinusDays(6)]],
+  [3, []],
+  [4, [todayMinusDays(0)]],
 ]);
 
 const achievement = {

--- a/test/lpt-locust/.releaserc.json
+++ b/test/lpt-locust/.releaserc.json
@@ -9,7 +9,7 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     ["@semantic-release/exec", {
-      "prepareCmd": "mkdir -p release && echo '${nextRelease.version}' > release/version.txt && echo '${nextRelease.notes}' > release/notes.md"
+      "prepareCmd": "mkdir -p release && echo '${nextRelease.version}' > release/version.txt && echo '${nextRelease.notes.replaceAll('\\'', '\\'\"\\'\"\\'')}' > release/notes.md"
     }]
   ],
   "skipTag": true,


### PR DESCRIPTION
Single quotes in a commit message were causing the exec
plugin of the semantic release process to execute an invalid
command.